### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ A Text-to-Speech MCP server plugin for Claude Code that converts text to speech 
 - **Cross-Platform**: macOS (afplay), Linux (mpv/ffplay/mpg123), Windows (PowerShell)
 - **Standalone CLI**: `speak-text` binary for direct TTS without MCP
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ybouhjira-claude-code-tts).
+
 ## Quick Install
 
 ```bash


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ybouhjira-claude-code-tts).